### PR TITLE
fix: route '/ddtf/builds' now always returns 'id: 1' and stores nothi…

### DIFF
--- a/lib/final-api/endpoint/ddtf.rb
+++ b/lib/final-api/endpoint/ddtf.rb
@@ -152,9 +152,7 @@ module FinalAPI
           end
 
           app.post '/ddtf/builds' do
-            build = DdtfHelpers.create_build(params['repository_id'], params['user_id'], params['config'])
-            halt 404 if build.nil?
-            FinalAPI::Builder.new(build).data.to_json
+            halt 200, { id: 1 }.to_json
           end
 
           app.post '/ddtf/builds/:build_id/jobs' do

--- a/spec/integration/endpoint/ddtf_spec.rb
+++ b/spec/integration/endpoint/ddtf_spec.rb
@@ -45,28 +45,11 @@ describe 'DDTF' do
       }
     end
 
-    it "create build and return its json" do
+    it "always returns pseudo-build with id: 1" do
       post '/ddtf/builds', payload, headers
       expect(last_response.status).to eq(200)
       response = MultiJson.load(last_response.body)
-      expect(response['config']['language']).to eq('tsd')
-    end
-
-    it "set build to 'started' state" do
-      post '/ddtf/builds', payload, headers
-      expect(last_response.status).to eq(200)
-      response = MultiJson.load(last_response.body)
-      expect(response['state']).to eq('created')
-    end
-
-    it 'returns 404 when user and repository not specified' do
-      post '/ddtf/builds', {}, headers
-      expect(last_response.status).to eq(404)
-    end
-
-    it 'returns 404 when user and repository not exists' do
-      post '/ddtf/builds', { user_id: 100_000, repository_id: 100_000 }, headers
-      expect(last_response.status).to eq(404)
+      expect(response['id']).to eq(1)
     end
   end
 


### PR DESCRIPTION
…ng to database
